### PR TITLE
DefaultProviders should prefer highest priority

### DIFF
--- a/code/Provider/ProviderFactory.cs
+++ b/code/Provider/ProviderFactory.cs
@@ -36,8 +36,11 @@ public static class ProviderFactory
         // Check for default provides
         var defaultTypes = types
             .Select(type => new KeyValuePair<TypeDescription, DefaultProviderAttribute>(type,
-                TypeLibrary.GetAttribute<DefaultProviderAttribute>(type.TargetType))).Where(pair => pair.Value != null)
-            .GroupBy(pair => pair.Value.Priority).OrderBy(group => group.Key).ToList();
+                TypeLibrary.GetAttribute<DefaultProviderAttribute>(type.TargetType)))
+            .Where(pair => pair.Value != null)
+            .GroupBy(pair => pair.Value.Priority)
+            .OrderByDescending(group => group.Key)
+            .ToList();
         if (defaultTypes.Any())
         {
             var defaultPriority = defaultTypes.First();


### PR DESCRIPTION
I believe your `OrderBy` is intended to be `OrderByDescending`.

I tried copying DefaultPermissionProvider + DefaultPermissionComponent into SandboxPlus (just to verify `HasPermission("noclip")` would actually work), setting a higher ProviderPriority, but my Client still just used your DefaultPermissionProvider (of priority -1).

```C#
[DefaultProvider( ProviderPriority.Medium )]
public class NebPermissionProvider : IPermissionProvider
{
	public IReadOnlyCollection<IPermissionComponent> Provide( IClient client )
	{
		return new List<IPermissionComponent> { new DefaultPermissionComponent( new List<string> { "spawn.prop" } ) }; // but not "noclip"
	}
}
```